### PR TITLE
Fix singularity install on arm64

### DIFF
--- a/apptainer-local-installer.bash
+++ b/apptainer-local-installer.bash
@@ -112,6 +112,10 @@ if [ -n "$doInstallGo" ] ; then
 			# Deriving the right name
 			GO_ARCH=amd64
 		;;
+		aarch64)
+			# Deriving the right name
+			GO_ARCH=arm64
+		;;
 	esac
 	goSoftDir="${downloadDir}/soft"
 	goBundle=go${GO_VER}.${GO_OS}-${GO_ARCH}.tar.gz

--- a/singularity-local-installer.bash
+++ b/singularity-local-installer.bash
@@ -112,6 +112,10 @@ if [ -n "$doInstallGo" ] ; then
 			# Deriving the right name
 			GO_ARCH=amd64
 		;;
+		aarch64)
+			# Deriving the right name
+			GO_ARCH=arm64
+		;;
 	esac
 	goSoftDir="${downloadDir}/soft"
 	goBundle=go${GO_VER}.${GO_OS}-${GO_ARCH}.tar.gz


### PR DESCRIPTION
# Description
- Added case to support `arm64` Go download in `singularity-local-installer.bash`
- Added case to support `arm64` Go download in `apptainer-local-installer.bash`, since the fix is the fix is the same.

## Notes
This is useful for developers on macs with apple silicon.