### PR TITLE
Fix `NameError` in `docker_container.py`

### DIFF
--- a/wfexs_backend/docker_container.py
+++ b/wfexs_backend/docker_container.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
         ContainerLocalConfig,
         ContainerOperatingSystem,
         ContainerTaggedName,
-        ContainerType,
         ExitVal,
         ProcessorArchitecture,
         RelPath,

--- a/wfexs_backend/docker_container.py
+++ b/wfexs_backend/docker_container.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
 
 from .common import (
     Container,
+    ContainerType,
     DEFAULT_DOCKER_CMD,
 )
 


### PR DESCRIPTION
# Description
When running wfexs with docker, the following error occurs:
```
...
File "/home/daniel/WfExS-backend/wfexs_backend/docker_container.py", line 89, in ContainerType
    return ContainerType.Docker
NameError: name 'ContainerType' is not defined. Did you mean: 'Container'?
```
This PR fixes this by importing `ContainerType` outside the `if` statement on line <insert line number> in `docker_container.py`