### PR TITLE
Fix uninitialised variable error

### DIFF
--- a/basic-installer.bash
+++ b/basic-installer.bash
@@ -112,7 +112,7 @@ else
 	echo "Creating WfExS-backend python virtual environment at ${envDir}"
 
 	# Checking whether the environment exists
-	if [ ! -f "${envActivate}" ] ; then
+	if [ ! -f "${envDir}" ] ; then
 		python3 -m venv "${envDir}"
 	fi
 


### PR DESCRIPTION
# Overview
When attempting to set WfExS up using an ansible script, funning `full-installer.bash` would throw an error pointing to line 115 in `basic-installer.bash` saying `/root/WfExS-backend/basic-installer.bash: line 115: envActivate: unbound variable`. This indicated an unassigned variable. Indeed, line 115 tries to use `envActivate` before it is assigned.

The following change corrects this behaviour.