### PR TITLE
Fixes related to image signatures handling

### DIFF
--- a/wfexs_backend/cache_handler.py
+++ b/wfexs_backend/cache_handler.py
@@ -1045,7 +1045,8 @@ class SchemeHandlerCacheHandler:
                 # Store the metadata
                 metadata_array.extend(cached_fetched_metadata_array)
                 licences.extend(the_licences)
-                final_fingerprint = metaStructure["fingerprint"]
+                if "fingerprint" in metaStructure:
+                    final_fingerprint = metaStructure["fingerprint"]
             elif offline:
                 # As this is a handler for online resources, comply with offline mode
                 raise CacheOfflineException(

--- a/wfexs_backend/container.py
+++ b/wfexs_backend/container.py
@@ -111,6 +111,7 @@ class Container(ContainerTaggedName):
     metadataLocalPath: The full local path to the container metadata file (it can be None)
     source_type: This one helps to identify transformations. The original source
     might be a docker registry, but the materialized one is a singularity image.
+    image_signature: The signature of the image
     """
 
     taggedName: "URIType" = cast("URIType", "")
@@ -121,6 +122,7 @@ class Container(ContainerTaggedName):
     fingerprint: "Optional[Fingerprint]" = None
     metadataLocalPath: "Optional[AbsPath]" = None
     source_type: "Optional[ContainerType]" = None
+    image_signature: "Optional[Fingerprint]" = None
 
     def _value_defaults_fixes(self) -> None:
         # This code is needed for old working directories

--- a/wfexs_backend/docker_container.py
+++ b/wfexs_backend/docker_container.py
@@ -497,6 +497,7 @@ STDERR
             registries=tag.registries,
             metadataLocalPath=containerPathMeta,
             source_type=tag.type,
+            image_signature=imageSignature,
         )
 
     def deploySingleContainer(

--- a/wfexs_backend/podman_container.py
+++ b/wfexs_backend/podman_container.py
@@ -525,6 +525,7 @@ STDERR
             registries=tag.registries,
             metadataLocalPath=containerPathMeta,
             source_type=tag.type,
+            image_signature=imageSignature,
         )
 
     def deploySingleContainer(

--- a/wfexs_backend/ro_crate.py
+++ b/wfexs_backend/ro_crate.py
@@ -346,6 +346,7 @@ class ContainerImageAdditionalType(enum.Enum):
 ContainerType2AdditionalType: "Mapping[ContainerType, ContainerImageAdditionalType]" = {
     ContainerType.Docker: ContainerImageAdditionalType.Docker,
     ContainerType.Singularity: ContainerImageAdditionalType.Singularity,
+    ContainerType.Podman: ContainerImageAdditionalType.Docker,
 }
 
 
@@ -1155,10 +1156,10 @@ you can find here an almost complete list of the possible ones:
                 )
                 if do_attach and container.localPath is not None:
                     the_size = os.stat(container.localPath).st_size
-                    assert container.signature is not None
-                    digest, algo = extract_digest(container.signature)
+                    assert container.image_signature is not None
+                    digest, algo = extract_digest(container.image_signature)
                     if digest is None:
-                        digest, algo = unstringifyDigest(container.signature)
+                        digest, algo = unstringifyDigest(container.image_signature)
                     assert algo is not None
                     the_signature = hexDigest(algo, digest)
 

--- a/wfexs_backend/singularity_container.py
+++ b/wfexs_backend/singularity_container.py
@@ -750,6 +750,7 @@ STDERR
             registries=tag.registries,
             metadataLocalPath=containerPathMeta,
             source_type=tag.type,
+            image_signature=imageSignature,
         )
 
     def materializeContainers(

--- a/wfexs_backend/utils/digests.py
+++ b/wfexs_backend/utils/digests.py
@@ -83,6 +83,8 @@ def stringifyDigest(digestAlgorithm: "str", digest: "bytes") -> "Fingerprint":
 
 
 def unstringifyDigest(digestion: "Fingerprint") -> "Tuple[bytes, str]":
+    if "=" not in digestion:
+        raise ValueError(f"The input string {digestion} is not a stringified digest")
     algo, b64digest = digestion.split("=", 1)
     return base64.b64decode(b64digest), algo
 


### PR DESCRIPTION
Team from TRE-FX realized there was an issue on newly executed workflows which use either podman or docker.

The issue was introduced one month ago in the rework of cache invalidation.