### PR TITLE
Added Python lazy loading capabilities.

### DIFF
--- a/WfExS-config-replicator.py
+++ b/WfExS-config-replicator.py
@@ -108,7 +108,7 @@ def loadXLSXParams(paramsFilename: "str") -> "Sequence[Mapping[str, Any]]":
     for sheet_raw in sheets:
         # This is needed to avoid a mypy error fired
         # by latest openpyxl annotations
-        sheet = cast("Worksheet", sheet_raw)
+        sheet = cast("Worksheet", sheet_raw)  # type: ignore[redundant-cast]
         gotHeader = False
         headerMap: "MutableMapping[int,str]" = {}
         for cells_in_row in sheet.iter_rows():

--- a/wfexs_backend/abstract_docker_container.py
+++ b/wfexs_backend/abstract_docker_container.py
@@ -34,7 +34,10 @@ from typing import (
     TYPE_CHECKING,
 )
 
-import magic
+from .utils.misc import lazy_import
+magic = lazy_import("magic")
+#import magic
+
 import pgzip
 
 from .common import (

--- a/wfexs_backend/abstract_docker_container.py
+++ b/wfexs_backend/abstract_docker_container.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020-2023 Barcelona Supercomputing Center (BSC), Spain
+# Copyright 2020-2024 Barcelona Supercomputing Center (BSC), Spain
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,8 +35,9 @@ from typing import (
 )
 
 from .utils.misc import lazy_import
+
 magic = lazy_import("magic")
-#import magic
+# import magic
 
 import pgzip
 

--- a/wfexs_backend/ro_crate.py
+++ b/wfexs_backend/ro_crate.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020-2023 Barcelona Supercomputing Center (BSC), Spain
+# Copyright 2020-2024 Barcelona Supercomputing Center (BSC), Spain
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -95,8 +95,9 @@ import urllib.parse
 import uuid
 
 from .utils.misc import lazy_import
+
 magic = lazy_import("magic")
-#import magic
+# import magic
 
 from rfc6920.methods import extract_digest
 import rocrate.model.entity

--- a/wfexs_backend/ro_crate.py
+++ b/wfexs_backend/ro_crate.py
@@ -94,7 +94,10 @@ if TYPE_CHECKING:
 import urllib.parse
 import uuid
 
-import magic
+from .utils.misc import lazy_import
+magic = lazy_import("magic")
+#import magic
+
 from rfc6920.methods import extract_digest
 import rocrate.model.entity
 import rocrate.model.dataset

--- a/wfexs_backend/utils/contents.py
+++ b/wfexs_backend/utils/contents.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020-2023 Barcelona Supercomputing Center (BSC), Spain
+# Copyright 2020-2024 Barcelona Supercomputing Center (BSC), Spain
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,8 +29,9 @@ from typing import (
 import data_url
 
 from .misc import lazy_import
+
 magic = lazy_import("magic")
-#import magic
+# import magic
 
 from ..common import (
     ContentKind,

--- a/wfexs_backend/utils/contents.py
+++ b/wfexs_backend/utils/contents.py
@@ -27,7 +27,10 @@ from typing import (
 )
 
 import data_url
-import magic
+
+from .misc import lazy_import
+magic = lazy_import("magic")
+#import magic
 
 from ..common import (
     ContentKind,

--- a/wfexs_backend/utils/misc.py
+++ b/wfexs_backend/utils/misc.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2020-2023 Barcelona Supercomputing Center (BSC), Spain
+# Copyright 2020-2024 Barcelona Supercomputing Center (BSC), Spain
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -273,8 +273,10 @@ def config_validate(
             f"FATAL ERROR: corrupted schema {relSchemaFile}. Reason: {e}"
         )
 
+
 import importlib.util
 import sys
+
 
 def lazy_import(name: "str") -> "ModuleType":
     module = sys.modules.get(name)

--- a/wfexs_backend/utils/misc.py
+++ b/wfexs_backend/utils/misc.py
@@ -29,6 +29,10 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from types import (
+        ModuleType,
+    )
+
     from typing import (
         Any,
         Iterator,
@@ -268,3 +272,24 @@ def config_validate(
         raise ConfigValidationException(
             f"FATAL ERROR: corrupted schema {relSchemaFile}. Reason: {e}"
         )
+
+import importlib.util
+import sys
+
+def lazy_import(name: "str") -> "ModuleType":
+    module = sys.modules.get(name)
+    if module is None:
+        spec = importlib.util.find_spec(name)
+        if spec is not None and spec.loader is not None:
+            loader = importlib.util.LazyLoader(spec.loader)
+            spec.loader = loader
+
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+
+            loader.exec_module(module)
+
+    if module is None:
+        raise ModuleNotFoundError(f"No module named '{name}'")
+
+    return module

--- a/wfexs_backend/wfexs_backend.py
+++ b/wfexs_backend/wfexs_backend.py
@@ -54,8 +54,9 @@ import crypt4gh.keys.kdf
 import crypt4gh.keys.c4gh
 
 from .utils.misc import lazy_import
+
 magic = lazy_import("magic")
-#import magic
+# import magic
 
 from .common import (
     AbstractWfExSException,

--- a/wfexs_backend/wfexs_backend.py
+++ b/wfexs_backend/wfexs_backend.py
@@ -53,7 +53,9 @@ import crypt4gh.lib
 import crypt4gh.keys.kdf
 import crypt4gh.keys.c4gh
 
-import magic
+from .utils.misc import lazy_import
+magic = lazy_import("magic")
+#import magic
 
 from .common import (
     AbstractWfExSException,


### PR DESCRIPTION
These capabilities are needed to delay issues with libraries like `python-magic`, which depends on having a locatable `libmagic.so` in the system. Loading of this library when `libmagic.so` is not available leads to an `ImportError`, even in scenarios where no one of its definitions is used.

This is needed to avoid having this `ImportError` when WfExS-backend is providing the list of parameters to autodoc in Sphinx run within the ReadTheDocs environment.