### PR TITLE
There was still an explicit import of `magic` in `wfexs_backend.utils…

### DIFF
--- a/wfexs_backend/utils/io_wrappers.py
+++ b/wfexs_backend/utils/io_wrappers.py
@@ -30,7 +30,12 @@ from typing import (
 import urllib.parse
 import uuid
 
-import magic
+from .misc import (
+    lazy_import,
+)
+
+magic = lazy_import("magic")
+# import magic
 
 if TYPE_CHECKING:
     from typing import (


### PR DESCRIPTION
….io_wrappers`. Translate it into a lazy_import.