### PR TITLE
Full circle: Nextflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
     name: Pre-commit python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,4 +28,4 @@ message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/inab/WfExS-backend"
 type: software
 title: "WfExS-backend"
-version: 0.99.1
+version: 0.99.2

--- a/README.md
+++ b/README.md
@@ -825,6 +825,10 @@ WfExS commands are:
 
 * `stage`: This command is used to first validate workflow staging and security context configuration files, then fetch all the workflow preconditions and files, staging them for an execution. It honours `-L`, `-W`, `-Z` parameters and `WFEXS_CONFIG_FILE` environment variable, and once the staging is finished it prints the path to the parent execution environment.
 
+* `re-stage`: This command is used to reuse an already staged workflow in a completely uncoupled working directory. The command allows replacing some of the parameters.
+
+* `import`: This command is used to fetch and import a previously generated Workflow Run RO-Crate, for reproducibility. The command allows replacing some of the original parameters, for replicability.
+
 * `staged-workdir`: This command is complementary to `stage`. It recognizes both `-L` parameter and `WFEXS_CONFIG_FILE` environment variable. This command has several subcommands which help on the workflow execution lifecycle (list available working directories and their statuses, remove some of them, execute either a shell or a custom command in a working directory context, execute, export prospective and retrospective provenance to RO-Crate, ...).
 
 * `export`: This command is complementary to `stage`. It recognizes both `-L` parameter and `WFEXS_CONFIG_FILE` environment variable, and depends on `-J` parameter to locate the execution environment directory to be used, properly staged through `stage`. It also depends on both -E and -Z parameters, to declare the different export patterns and the needed credentials to complete the rules. This command has a couple of subcommands to list previously exported items and to do those exports.

--- a/wfexs_backend/__init__.py
+++ b/wfexs_backend/__init__.py
@@ -21,7 +21,7 @@ __copyright__ = "© 2020-2024 Barcelona Supercomputing Center (BSC), ES"
 __license__ = "Apache 2.0"
 
 # https://www.python.org/dev/peps/pep-0396/
-__version__ = "0.99.1"
+__version__ = "0.99.2"
 __url__ = "https://github.com/inab/WfExS-backend"
 __official_name__ = "WfExS-backend"
 

--- a/wfexs_backend/common.py
+++ b/wfexs_backend/common.py
@@ -416,6 +416,8 @@ class ExpectedOutput(NamedTuple):
     glob: When the workflow engine does not use symbolic
       names to label the outputs, this is the filename pattern to capture the
       local path, based on the output / working directory.
+    syntheticOutput: It is true for outputs which do not really exist
+    either as parameter or explicit outputs.
     """
 
     name: "SymbolicOutputName"
@@ -424,9 +426,10 @@ class ExpectedOutput(NamedTuple):
     cardinality: "Tuple[int, int]"
     fillFrom: "Optional[SymbolicParamName]" = None
     glob: "Optional[GlobPattern]" = None
+    syntheticOutput: "Optional[bool]" = None
 
     def _marshall(self) -> "MutableMapping[str, Any]":
-        mD = {
+        mD: "MutableMapping[str, Any]" = {
             "c-l-a-s-s": self.kind.name,
             "cardinality": list(self.cardinality),
         }
@@ -437,6 +440,8 @@ class ExpectedOutput(NamedTuple):
             mD["glob"] = self.glob
         if self.fillFrom is not None:
             mD["fillFrom"] = self.fillFrom
+        if self.syntheticOutput is not None:
+            mD["syntheticOutput"] = self.syntheticOutput
 
         return mD
 
@@ -451,6 +456,7 @@ class ExpectedOutput(NamedTuple):
             fillFrom=obj.get("fillFrom"),
             glob=obj.get("glob"),
             cardinality=cast("Tuple[int, int]", tuple(obj["cardinality"])),
+            syntheticOutput=cast("Optional[bool]", obj.get("syntheticOutput")),
         )
 
 
@@ -525,6 +531,7 @@ class MaterializedOutput(NamedTuple):
     kind: "ContentKind"
     expectedCardinality: "Tuple[int, int]"
     values: "Union[Sequence[bool], Sequence[str], Sequence[int], Sequence[float], Sequence[AbstractGeneratedContent]]"
+    syntheticOutput: "Optional[bool]" = None
 
 
 class LocalWorkflow(NamedTuple):

--- a/wfexs_backend/common.py
+++ b/wfexs_backend/common.py
@@ -532,6 +532,8 @@ class MaterializedOutput(NamedTuple):
     expectedCardinality: "Tuple[int, int]"
     values: "Union[Sequence[bool], Sequence[str], Sequence[int], Sequence[float], Sequence[AbstractGeneratedContent]]"
     syntheticOutput: "Optional[bool]" = None
+    filledFrom: "Optional[str]" = None
+    glob: "Optional[GlobPattern]" = None
 
 
 class LocalWorkflow(NamedTuple):

--- a/wfexs_backend/ro_crate.py
+++ b/wfexs_backend/ro_crate.py
@@ -1768,7 +1768,7 @@ you can find here an almost complete list of the possible ones:
             dest_path=the_name if do_attach else None,
             clazz=SourceCodeFile if is_soft_source else FixedFile,
         )
-        if do_attach and (the_uri is not None):
+        if the_uri is not None:
             if the_uri.startswith("http") or the_uri.startswith("ftp"):
                 # See https://github.com/ResearchObject/ro-crate/pull/259
                 uri_key = "contentUrl"
@@ -1845,7 +1845,7 @@ you can find here an almost complete list of the possible ones:
             validate_url=False,
             # properties=file_properties,
         )
-        if do_attach and (the_uri is not None):
+        if the_uri is not None:
             if the_uri.startswith("http") or the_uri.startswith("ftp"):
                 # See https://github.com/ResearchObject/ro-crate/pull/259
                 uri_key = "contentUrl"
@@ -2092,7 +2092,7 @@ you can find here an almost complete list of the possible ones:
                 if added_operational_container not in existing_operational_containers:
                     existing_operational_containers.append(added_operational_container)
 
-        if do_attach and (the_uri is not None):
+        if the_uri is not None:
             if the_uri.startswith("http") or the_uri.startswith("ftp"):
                 # See https://github.com/ResearchObject/ro-crate/pull/259
                 uri_key = "contentUrl"
@@ -2750,7 +2750,7 @@ you can find here an almost complete list of the possible ones:
                 # properties=file_properties,
             )
 
-            if do_attach and (the_uri is not None):
+            if the_uri is not None:
                 if the_uri.startswith("http") or the_uri.startswith("ftp"):
                     # See https://github.com/ResearchObject/ro-crate/pull/259
                     uri_key = "contentUrl"

--- a/wfexs_backend/ro_crate.py
+++ b/wfexs_backend/ro_crate.py
@@ -1337,6 +1337,11 @@ you can find here an almost complete list of the possible ones:
 
         failed_licences: "MutableSequence[URIType]" = []
         for in_item in inputs:
+            # Skip autoFilled inputs, as they should have their
+            # mirror parameters in outputs
+            if in_item.autoFilled:
+                continue
+
             formal_parameter_id = (
                 f"{self.wf_file.id}#{input_sep}:"
                 + urllib.parse.quote(in_item.name, safe="")
@@ -2195,6 +2200,11 @@ you can find here an almost complete list of the possible ones:
                     identifier=formal_parameter_id,
                     additional_type=additional_type,
                 )
+
+                # This one must be a real boolean, as of schema.org
+                if out_item.syntheticOutput is not None:
+                    formal_parameter["valueRequired"] = not out_item.syntheticOutput
+
                 self.crate.add(formal_parameter)
 
             # Add to the list only when it is needed
@@ -2506,6 +2516,11 @@ you can find here an almost complete list of the possible ones:
                     identifier=formal_parameter_id,
                     additional_type=additional_type,
                 )
+
+                # This one must be a real boolean, as of schema.org
+                if out_item.syntheticOutput is not None:
+                    formal_parameter["valueRequired"] = not out_item.syntheticOutput
+
                 self.crate.add(formal_parameter)
                 self.wf_file.append_to("output", formal_parameter, compact=True)
 

--- a/wfexs_backend/schemas/stage-definition.json
+++ b/wfexs_backend/schemas/stage-definition.json
@@ -237,6 +237,7 @@
 					"minLength": 1
 				},
 				"security-context": {
+					"description": "Use an explicitly named security context",
 					"type": "string",
 					"minLength": 1
 				},
@@ -250,6 +251,7 @@
 					"default": false
 				},
 				"autoPrefix": {
+					"description": "When autoFill is true and this parameter is false, this directory is mapped to the parent output one for this execution. When both autoFill and this parameter are true, an output file or directory name is assigned, based on its complete param name",
 					"type": "boolean",
 					"default": false
 				}
@@ -732,6 +734,10 @@
 							"description": "Autofilled input from where to get the files and directories to be assigned to this output, useful in workflow models where outputs are not explicitly declared (Nextflow, Snakemake)",
 							"type": "string",
 							"minLength": 1
+						},
+						"syntheticOutput": {
+							"description": "Is this output a synthetic one? The default value when it is not defined depends on the type of workflow.",
+							"type": "boolean"
 						},
 						"glob": {
 							"description": "Glob pattern to get the files and directories to be assigned to this output, useful in workflow models where outputs are not explicitly declared (Nextflow, Snakemake)",

--- a/wfexs_backend/utils/rocrate.py
+++ b/wfexs_backend/utils/rocrate.py
@@ -600,7 +600,7 @@ WHERE   {
     # This compound query is much faster when each of the UNION components
     # is evaluated separately
     OBTAIN_WORKFLOW_INPUTS_SPARQL: "Final[str]" = """\
-SELECT  ?input ?name ?inputfp ?additional_type ?fileuri ?value ?component ?leaf_type
+SELECT  ?input ?name ?inputfp ?additional_type ?fileuri ?filepid ?value ?component ?leaf_type
 WHERE   {
     ?main_entity bsworkflow:input ?inputfp .
     ?inputfp
@@ -611,13 +611,27 @@ WHERE   {
     {
         # A file, which is a schema.org MediaObject
         ?input
-            a s:MediaObject ;
-            s:contentUrl ?fileuri .
+            a s:MediaObject .
+        OPTIONAL {
+            ?input
+                s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?input
+                s:identifier ?filepid .
+        }
     } UNION {
         # A directory, which is a schema.org Dataset
         ?input
-            a s:Dataset ;
-            s:contentUrl ?fileuri .
+            a s:Dataset .
+        OPTIONAL {
+            ?input
+                s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?input
+                s:identifier ?filepid .
+        }
         FILTER EXISTS { 
             # subquery to determine it is not an empty Dataset
             SELECT ?dircomp
@@ -645,6 +659,9 @@ WHERE   {
             ?component s:contentUrl ?fileuri .
         }
         OPTIONAL {
+            ?component s:identifier ?filepid .
+        }
+        OPTIONAL {
             ?component s:value ?value .
         }
     }
@@ -654,7 +671,7 @@ WHERE   {
     # This compound query is much faster when each of the UNION components
     # is evaluated separately
     OBTAIN_WORKFLOW_ENV_SPARQL: "Final[str]" = """\
-SELECT  ?env ?name ?name_env ?envfp ?additional_type ?fileuri ?value ?component ?leaf_type
+SELECT  ?env ?name ?name_env ?envfp ?additional_type ?fileuri ?filepid ?value ?component ?leaf_type
 WHERE   {
     ?main_entity wrterm:environment ?envfp .
     ?envfp
@@ -666,14 +683,28 @@ WHERE   {
         # A file, which is a schema.org MediaObject
         ?env
             a s:MediaObject ;
-            s:name ?name_env ;
-            s:contentUrl ?fileuri .
+            s:name ?name_env .
+        OPTIONAL {
+            ?env
+                s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?env
+                s:identifier ?filepid .
+        }
     } UNION {
         # A directory, which is a schema.org Dataset
         ?env
             a s:Dataset ;
-            s:name ?name_env ;
-            s:contentUrl ?fileuri .
+            s:name ?name_env .
+        OPTIONAL {
+            ?env
+                s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?env
+                s:identifier ?filepid .
+        }
         FILTER EXISTS { 
             # subquery to determine it is not an empty Dataset
             SELECT ?dircomp
@@ -701,6 +732,9 @@ WHERE   {
             a ?leaf_type .
         OPTIONAL {
             ?component s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?component s:identifer ?filepid .
         }
         OPTIONAL {
             ?component s:value ?value .
@@ -741,7 +775,7 @@ WHERE   {
     # This compound query is much faster when each of the UNION components
     # is evaluated separately
     OBTAIN_EXECUTION_INPUTS_SPARQL: "Final[str]" = """\
-SELECT  ?input ?name ?inputfp ?additional_type ?fileuri ?value ?component ?leaf_type
+SELECT  ?input ?name ?inputfp ?additional_type ?fileuri ?filepid ?value ?component ?leaf_type
 WHERE   {
     ?execution s:object ?input .
     {
@@ -754,6 +788,10 @@ WHERE   {
             ?input
                 s:contentUrl ?fileuri .
         }
+        OPTIONAL {
+            ?input
+                s:identifier ?filepid .
+        }
         ?inputfp
             a bs:FormalParameter ;
             s:name ?name ;
@@ -763,11 +801,14 @@ WHERE   {
         BIND ( "Dataset" AS ?additional_type )
         ?input
             a s:Dataset ;
-            s:contentUrl ?fileuri ;
             s:exampleOfWork ?inputfp .
         OPTIONAL {
             ?input
                 s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?input
+                s:identifier ?filepid .
         }
         ?inputfp
             a bs:FormalParameter ;
@@ -810,6 +851,9 @@ WHERE   {
             a ?leaf_type .
         OPTIONAL {
             ?component s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?component s:identifier ?filepid .
         }
         OPTIONAL {
             ?component s:value ?value .
@@ -821,7 +865,7 @@ WHERE   {
     # This compound query is much faster when each of the UNION components
     # is evaluated separately
     OBTAIN_EXECUTION_ENV_SPARQL: "Final[str]" = """\
-SELECT  ?env ?name ?name_env ?envfp ?additional_type ?fileuri ?value ?component ?leaf_type
+SELECT  ?env ?name ?name_env ?envfp ?additional_type ?fileuri ?filepid ?value ?component ?leaf_type
 WHERE   {
     ?execution wrterm:environment ?env .
     {
@@ -830,8 +874,15 @@ WHERE   {
         ?env
             a s:MediaObject ;
             s:name ?name_env ;
-            s:contentUrl ?fileuri ;
             s:exampleOfWork ?envfp .
+        OPTIONAL {
+            ?env
+                s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?env
+                s:identifier ?filepid .
+        }
         ?envfp
             a bs:FormalParameter ;
             s:name ?name ;
@@ -842,8 +893,15 @@ WHERE   {
         ?env
             a s:Dataset ;
             s:name ?name_env ;
-            s:contentUrl ?fileuri ;
             s:exampleOfWork ?envfp .
+        OPTIONAL {
+            ?env
+                s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?env
+                s:identifier ?filepid .
+        }
         ?envfp
             a bs:FormalParameter ;
             s:name ?name ;
@@ -889,6 +947,9 @@ WHERE   {
             ?component s:contentUrl ?fileuri .
         }
         OPTIONAL {
+            ?component s:identifier ?filepid .
+        }
+        OPTIONAL {
             ?component s:value ?value .
         }
     }
@@ -898,7 +959,7 @@ WHERE   {
     # This compound query is much faster when each of the UNION components
     # is evaluated separately
     OBTAIN_EXECUTION_OUTPUTS_SPARQL: "Final[str]" = """\
-SELECT  ?output ?name ?alternate_name ?outputfp ?default_value ?additional_type ?fileuri ?value ?component ?leaf_type ?synthetic_output ?glob_pattern ?filled_from_name
+SELECT  ?output ?name ?alternate_name ?outputfp ?default_value ?additional_type ?fileuri ?filepid ?value ?component ?leaf_type ?synthetic_output ?glob_pattern ?filled_from_name
 WHERE   {
     ?execution s:result ?output .
     {
@@ -914,6 +975,10 @@ WHERE   {
         OPTIONAL {
             ?output
                 s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?output
+                s:identifier ?filepid .
         }
     } UNION {
         # A directory, which is a schema.org Dataset
@@ -939,6 +1004,10 @@ WHERE   {
             ?output
                 s:contentUrl ?fileuri .
         }
+        OPTIONAL {
+            ?output
+                s:identifier ?filepid .
+        }
     } UNION {
         # A single property value, which can be either Integer, Text, Boolean or Float
         VALUES (?additional_type) { ( "Integer" ) ( "Text" ) ( "Boolean" ) ( "Float" ) }
@@ -966,6 +1035,9 @@ WHERE   {
             a ?leaf_type .
         OPTIONAL {
             ?component s:contentUrl ?fileuri .
+        }
+        OPTIONAL {
+            ?component s:identifier ?filepid .
         }
         OPTIONAL {
             ?component s:value ?value .
@@ -1433,8 +1505,8 @@ Container {containerrow.container}
 
             # Is it a file or a directory?
             if additional_type in ("File", "Dataset"):
-                if inputrow.fileuri is None:
-                    errmsg = f"Input parameter {inputrow.name} from {public_name} is of type {additional_type}, but no associated contentUrl was found. Stopping."
+                if inputrow.fileuri is None and inputrow.filepid is None:
+                    errmsg = f"Input parameter {inputrow.name} from {public_name} is of type {additional_type}, but no associated `contentUrl` or `identifier` were found. Stopping."
                     self.logger.error(errmsg)
                     raise ROCrateToolboxException(errmsg)
                 valobj = base.setdefault(
@@ -1450,12 +1522,22 @@ Container {containerrow.container}
                 licences = self._getLicences(g, inputrow.input, public_name)
                 if len(licences) == 0:
                     licences = default_licences
+                the_uri: "str"
+                if inputrow.fileuri is not None:
+                    the_uri = str(inputrow.fileuri)
+                elif inputrow.filepid is not None:
+                    the_uri = str(inputrow.filepid)
+                else:
+                    raise ROCrateToolboxException(
+                        "FATAL RO-Crate workflow input processing error. Check the code of WfExS"
+                    )
+
                 the_url: "Union[str, Mapping[str, Any]]"
                 if len(licences) == 0:
-                    the_url = str(inputrow.fileuri)
+                    the_url = the_uri
                 else:
                     the_url = {
-                        "uri": str(inputrow.fileuri),
+                        "uri": the_uri,
                         "licences": licences,
                     }
 

--- a/wfexs_backend/utils/rocrate.py
+++ b/wfexs_backend/utils/rocrate.py
@@ -495,50 +495,6 @@ WHERE   {
 }
 """
 
-    OBTAIN_WF_CONTAINERS_SPARQL: "Final[str]" = """\
-SELECT ?container ?container_additional_type ?type_of_container ?type_of_container_type ?container_registry ?container_name ?container_tag ?container_sha256 ?container_platform ?container_arch
-WHERE   {
-    ?entity s:softwareAddOn ?container.
-    ?container
-        a wrterm:ContainerImage ;
-        s:additionalType ?container_additional_type .
-    OPTIONAL {
-        ?container
-            s:softwareRequirements ?container_type ;
-            s:applicationCategory ?type_of_container .
-        ?container_type
-            a s:SoftwareApplication ;
-            s:applicationCategory ?type_of_container_type .
-        FILTER(
-            STRSTARTS(str(?type_of_container), str(wikidata:)) &&
-            STRSTARTS(str(?type_of_container_type), str(wikidata:))
-        ) .
-    }
-    OPTIONAL {
-        ?container wrterm:registry ?container_registry .
-    }
-    OPTIONAL {
-        ?container s:name ?container_name .
-    }
-    OPTIONAL {
-        ?container wrterm:tag ?container_tag .
-    }
-    OPTIONAL {
-        ?container wrterm:sha256 ?container_sha256 .
-    }
-    OPTIONAL {
-        ?container
-            a s:SoftwareApplication ;
-            s:operatingSystem ?container_platform .
-    }
-    OPTIONAL {
-        ?container
-            a s:SoftwareApplication ;
-            s:processorRequirements ?container_arch .
-    }
-}
-"""
-
     # This compound query is much faster when each of the UNION components
     # is evaluated separately
     OBTAIN_WORKFLOW_INPUTS_SPARQL: "Final[str]" = """\

--- a/wfexs_backend/utils/rocrate.py
+++ b/wfexs_backend/utils/rocrate.py
@@ -153,6 +153,8 @@ ApplicationCategory2ContainerType: "Final[Mapping[str, ContainerType]]" = {
 WORKFLOW_RUN_CONTEXT: "Final[str]" = "https://w3id.org/ro/terms/workflow-run"
 WORKFLOW_RUN_NAMESPACE: "Final[str]" = WORKFLOW_RUN_CONTEXT + "#"
 
+WFEXS_CONTEXT: "Final[str]" = "https://w3id.org/ro/terms/wfexs"
+WFEXS_NAMESPACE: "Final[str]" = WFEXS_CONTEXT + "#"
 
 CONTAINER_DOCKERIMAGE_SHORT: "Final[str]" = "DockerImage"
 CONTAINER_SIFIMAGE_SHORT: "Final[str]" = "SIFImage"

--- a/wfexs_backend/utils/rocrate.py
+++ b/wfexs_backend/utils/rocrate.py
@@ -2020,13 +2020,17 @@ Container {containerrow.container}
                 if not output_decl.get("syntheticOutput", False):
                     # Additional check
                     fill_from = output_decl.get("fillFrom")
-                    if fill_from == output_name:
-                        # Now, inject an input
-                        new_params[output_name] = {
-                            "c-l-a-s-s": output_decl["c-l-a-s-s"],
-                            "autoFill": True,
-                            "autoPrefix": True,
-                        }
+                    if fill_from != output_name:
+                        self.logger.warning(
+                            f"fillFrom property differs from what it is expected: {fill_from} vs {output_name} . Fixing"
+                        )
+                        output_decl["fillFrom"] = output_name
+                    # Now, inject an input
+                    new_params[output_name] = {
+                        "c-l-a-s-s": output_decl["c-l-a-s-s"],
+                        "autoFill": True,
+                        "autoPrefix": True,
+                    }
             params = new_params
 
         return (

--- a/wfexs_backend/utils/rocrate.py
+++ b/wfexs_backend/utils/rocrate.py
@@ -749,8 +749,11 @@ WHERE   {
         BIND ( "File" AS ?additional_type )
         ?input
             a s:MediaObject ;
-            s:contentUrl ?fileuri ;
             s:exampleOfWork ?inputfp .
+        OPTIONAL {
+            ?input
+                s:contentUrl ?fileuri .
+        }
         ?inputfp
             a bs:FormalParameter ;
             s:name ?name ;
@@ -762,6 +765,10 @@ WHERE   {
             a s:Dataset ;
             s:contentUrl ?fileuri ;
             s:exampleOfWork ?inputfp .
+        OPTIONAL {
+            ?input
+                s:contentUrl ?fileuri .
+        }
         ?inputfp
             a bs:FormalParameter ;
             s:name ?name ;
@@ -1426,6 +1433,10 @@ Container {containerrow.container}
 
             # Is it a file or a directory?
             if additional_type in ("File", "Dataset"):
+                if inputrow.fileuri is None:
+                    errmsg = f"Input parameter {inputrow.name} from {public_name} is of type {additional_type}, but no associated contentUrl was found. Stopping."
+                    self.logger.error(errmsg)
+                    raise ROCrateToolboxException(errmsg)
                 valobj = base.setdefault(
                     param_last,
                     {

--- a/wfexs_backend/workflow.py
+++ b/wfexs_backend/workflow.py
@@ -59,6 +59,7 @@ from .fetchers import (
     FetcherException,
     # Next ones are needed for correct unmarshalling
     RemoteRepo,
+    RepoGuessFlavor,
     RepoType,
 )
 
@@ -155,6 +156,7 @@ if TYPE_CHECKING:
     Sch_InputURI_Fetchable = Union[Sch_InputURI_Elem, Sequence[Sch_InputURI_Elem]]
     Sch_InputURI = Union[Sch_InputURI_Fetchable, Sequence[Sequence[Sch_InputURI_Elem]]]
 
+    # Remember to change this if the JSON schema is changed
     Sch_Tabular = TypedDict(
         "Sch_Tabular",
         {
@@ -165,6 +167,7 @@ if TYPE_CHECKING:
         },
     )
 
+    # Remember to change this if the JSON schema is changed
     Sch_Param = TypedDict(
         "Sch_Param",
         {
@@ -179,6 +182,20 @@ if TYPE_CHECKING:
             "globExplode": str,
             "autoFill": bool,
             "autoPrefix": bool,
+        },
+        total=False,
+    )
+
+    # Remember to change this if the JSON schema is changed
+    Sch_Output = TypedDict(
+        "Sch_Output",
+        {
+            "c-l-a-s-s": str,
+            "cardinality": Union[str, int, Sequence[int]],
+            "preferredName": str,
+            "fillFrom": str,
+            "glob": str,
+            "syntheticOutput": bool,
         },
         total=False,
     )
@@ -228,20 +245,14 @@ from .utils.licences import (
     AcceptableLicenceSchemes,
     LicenceMatcherSingleton,
 )
-from .utils.misc import (
-    lazy_import,
-)
 from .utils.rocrate import (
-    ROCrateToolbox,
+    ReadROCrateMetadata,
 )
 
 from .security_context import (
     SecurityContextVault,
 )
 import bagit
-
-magic = lazy_import("magic")
-# import magic
 
 from . import __url__ as wfexs_backend_url
 from . import __official_name__ as wfexs_backend_name
@@ -376,10 +387,6 @@ class DefaultMissing(Dict[KT, VT]):
 
     def __missing__(self, key: KT) -> VT:
         return cast(VT, key)
-
-
-ROCRATE_JSONLD_FILENAME: "Final[str]" = "ro-crate-metadata.json"
-LEGACY_ROCRATE_JSONLD_FILENAME: "Final[str]" = "ro-crate-metadata.jsonld"
 
 
 def _wakeupEncDir(
@@ -526,7 +533,7 @@ class WF:
         # This property should mutate after unmarshalling the config
         self.container_type_str = container_type_str
 
-        self.outputs: "Optional[Sequence[ExpectedOutput]]"
+        self.expected_outputs: "Optional[Sequence[ExpectedOutput]]" = None
         self.default_actions: "Optional[Sequence[ExportAction]]"
         self.trs_endpoint: "Optional[str]"
         self.version_id: "Optional[WFVersionId]"
@@ -595,9 +602,10 @@ class WF:
             self.params = params
             self.environment = environment
             self.placeholders = placeholders
-            self.formatted_params = self.formatParams(params)
-            self.formatted_environment = self.formatParams(environment)
-            self.outputs = self.parseExpectedOutputs(outputs)
+            self.formatted_params, self.outputs_to_inject = self.formatParams(params)
+            assert self.outputs_to_inject is not None
+            self.formatted_environment, _ = self.formatParams(environment)
+            self.outputs = outputs
             self.default_actions = self.parseExportActions(
                 [] if default_actions is None else default_actions
             )
@@ -1400,67 +1408,7 @@ class WF:
         based on the declaration of an existing one
         """
 
-        # Is it a bare file or an archive?
-        jsonld_filename: "Optional[str]" = None
-        if os.path.isdir(workflowROCrateFilename):
-            possible_jsonld_filename = os.path.join(
-                workflowROCrateFilename, ROCRATE_JSONLD_FILENAME
-            )
-            legacy_jsonld_filename = os.path.join(
-                workflowROCrateFilename, LEGACY_ROCRATE_JSONLD_FILENAME
-            )
-            if os.path.exists(possible_jsonld_filename):
-                jsonld_filename = possible_jsonld_filename
-            elif os.path.exists(legacy_jsonld_filename):
-                jsonld_filename = legacy_jsonld_filename
-            else:
-                raise WFException(
-                    f"{public_name} does not contain a member {ROCRATE_JSONLD_FILENAME} or {LEGACY_ROCRATE_JSONLD_FILENAME}"
-                )
-        elif os.path.isfile(workflowROCrateFilename):
-            jsonld_filename = workflowROCrateFilename
-        else:
-            raise WFException(f"Input {public_name} is neither a file or a directory")
-
-        jsonld_bin: "Optional[bytes]" = None
-        putative_mime = magic.from_file(jsonld_filename, mime=True)
-        # Bare possible RO-Crate
-        if putative_mime == "application/json":
-            with open(jsonld_filename, mode="rb") as jdf:
-                jsonld_bin = jdf.read()
-        # Archived possible RO-Crate
-        elif putative_mime == "application/zip":
-            with zipfile.ZipFile(workflowROCrateFilename, mode="r") as zf:
-                try:
-                    jsonld_bin = zf.read(ROCRATE_JSONLD_FILENAME)
-                except Exception as e:
-                    try:
-                        jsonld_bin = zf.read(LEGACY_ROCRATE_JSONLD_FILENAME)
-                    except Exception as e2:
-                        raise WFException(
-                            f"Unable to locate RO-Crate metadata descriptor within {public_name}"
-                        ) from ExceptionGroup(  # pylint: disable=possibly-used-before-assignment
-                            f"Both {ROCRATE_JSONLD_FILENAME} and {LEGACY_ROCRATE_JSONLD_FILENAME} tried",
-                            [e, e2],
-                        )
-
-                putative_mime_ld = magic.from_buffer(jsonld_bin, mime=True)
-                if putative_mime_ld != "application/json":
-                    raise WFException(
-                        f"{ROCRATE_JSONLD_FILENAME} from within {public_name} has unmanagable MIME {putative_mime_ld}"
-                    )
-        else:
-            raise WFException(
-                f"The RO-Crate parsing code does not know how to parse {public_name} with MIME {putative_mime}"
-            )
-
-        # Let's parse the JSON (in order to check whether it is valid)
-        try:
-            jsonld_obj = json.loads(jsonld_bin)
-        except json.JSONDecodeError as jde:
-            raise WFException(
-                f"Content from {public_name} is not a valid JSON"
-            ) from jde
+        jsonld_obj = ReadROCrateMetadata(workflowROCrateFilename, public_name)
 
         (
             repo,
@@ -1757,6 +1705,23 @@ class WF:
         assert (
             self.engine is not None
         ), "Workflow engine not properly identified or set up"
+
+        # Process outputs now we have an engine
+        if isinstance(self.outputs, dict):
+            assert self.outputs_to_inject is not None
+            outputs = list(self.outputs.values())
+            if (len(outputs) == 0 and len(self.outputs_to_inject) == 0) or (
+                len(outputs) > 0 and isinstance(outputs[0], ExpectedOutput)
+            ):
+                self.expected_outputs = outputs
+            else:
+                self.expected_outputs = self.parseExpectedOutputs(
+                    self.outputs_to_inject,
+                    self.outputs,
+                    default_synthetic_output=not self.engine.HasExplicitOutputs(),
+                )
+        else:
+            self.expected_outputs = None
 
         engine_version: "Optional[EngineVersion]"
         if self.materializedEngine is None:
@@ -2170,10 +2135,11 @@ class WF:
 
     def formatParams(
         self, params: "Optional[ParamsBlock]", prefix: "str" = ""
-    ) -> "Optional[ParamsBlock]":
+    ) -> "Tuple[Optional[ParamsBlock] , Optional[Sequence[Sch_Output]]]":
         if params is None:
-            return None
+            return None, None
 
+        outputs_to_inject: "MutableSequence[Sch_Output]" = []
         formatted_params: "MutableParamsBlock" = dict()
         some_formatted = False
         for key, raw_inputs in params.items():
@@ -2194,23 +2160,75 @@ class WF:
                                 inputClass, linearKey
                             )
                         )
+
+                    prefrel_formatted = False
+                    formatted_preferred_name_conf: "Optional[Union[str, Literal[False]]]" = (
+                        None
+                    )
+                    formatted_reldir_conf: "Optional[Union[str, Literal[False]]]" = None
                     if inputClass in (
                         ContentKind.File.name,
                         ContentKind.Directory.name,
-                    ):  # input files
-                        if inputClass == ContentKind.Directory.name:
-                            # We have to autofill this with the outputs directory,
-                            # so results are properly stored (without escaping the jail)
-                            if inputs.get("autoFill", False):
-                                formatted_params[key] = inputs
-                                continue
+                        ContentKind.ContentWithURIs.name,
+                    ):
+                        # These parameters can be used both for input placement tuning
+                        # as well for output placement
+                        preferred_name_conf = inputs.get("preferred-name")
+                        if isinstance(preferred_name_conf, str):
+                            formatted_preferred_name_conf = (
+                                self._formatStringFromPlaceHolders(preferred_name_conf)
+                            )
+                            if preferred_name_conf != formatted_preferred_name_conf:
+                                prefrel_formatted = True
+                        else:
+                            formatted_preferred_name_conf = preferred_name_conf
 
-                            globExplode = inputs.get("globExplode")
-                        elif inputClass == ContentKind.File.name and inputs.get(
-                            "autoFill", False
-                        ):
-                            formatted_params[key] = inputs
+                        reldir_conf = inputs.get("relative-dir")
+                        if isinstance(reldir_conf, str):
+                            formatted_reldir_conf = self._formatStringFromPlaceHolders(
+                                reldir_conf
+                            )
+                            if reldir_conf != formatted_reldir_conf:
+                                prefrel_formatted = True
+                        else:
+                            formatted_reldir_conf = reldir_conf
+
+                    if inputClass in (
+                        ContentKind.File.name,
+                        ContentKind.Directory.name,
+                    ):
+                        # input files
+                        # We have to autofill this with the outputs directory,
+                        # so results are properly stored (without escaping the jail)
+                        if inputs.get("autoFill", False):
+                            if prefrel_formatted:
+                                some_formatted = True
+                                formatted_inputs = copy.copy(inputs)
+                                if formatted_preferred_name_conf is not None:
+                                    formatted_inputs[
+                                        "preferred-name"
+                                    ] = formatted_preferred_name_conf
+                                if formatted_reldir_conf is not None:
+                                    formatted_inputs[
+                                        "relative-dir"
+                                    ] = formatted_reldir_conf
+                            else:
+                                formatted_inputs = inputs
+                            formatted_params[key] = formatted_inputs
+
+                            # Inject as an output
+                            outputs_to_inject.append(
+                                {
+                                    "c-l-a-s-s": inputClass,
+                                    "cardinality": 1,
+                                    "fillFrom": linearKey,
+                                    "syntheticOutput": False,
+                                }
+                            )
                             continue
+
+                        if inputClass == ContentKind.Directory.name:
+                            globExplode = inputs.get("globExplode")
 
                     # Processing url and secondary-urls
                     if ("url" in inputs) and (
@@ -2220,8 +2238,9 @@ class WF:
                             ContentKind.Directory.name,
                             ContentKind.ContentWithURIs.name,
                         )
-                    ):  # input files
-                        was_formatted = False
+                    ):
+                        # input files
+                        was_formatted = prefrel_formatted
 
                         remote_files: "Sch_InputURI" = inputs["url"]
                         if remote_files is not None:
@@ -2250,28 +2269,6 @@ class WF:
                         else:
                             formatted_secondary_remote_files = None
 
-                        preferred_name_conf = inputs.get("preferred-name")
-                        formatted_preferred_name_conf: "Optional[Union[str, Literal[False]]]"
-                        if isinstance(preferred_name_conf, str):
-                            formatted_preferred_name_conf = (
-                                self._formatStringFromPlaceHolders(preferred_name_conf)
-                            )
-                            if preferred_name_conf != formatted_preferred_name_conf:
-                                was_formatted = True
-                        else:
-                            formatted_preferred_name_conf = preferred_name_conf
-
-                        reldir_conf = inputs.get("relative-dir")
-                        formatted_reldir_conf: "Optional[Union[str, Literal[False]]]"
-                        if isinstance(reldir_conf, str):
-                            formatted_reldir_conf = self._formatStringFromPlaceHolders(
-                                reldir_conf
-                            )
-                            if reldir_conf != formatted_reldir_conf:
-                                was_formatted = True
-                        else:
-                            formatted_reldir_conf = reldir_conf
-
                         # Something has to be changed
                         if was_formatted:
                             some_formatted = True
@@ -2283,13 +2280,11 @@ class WF:
                                 formatted_inputs[
                                     "secondary-urls"
                                 ] = formatted_secondary_remote_files
-                            if "preferred-name" in inputs:
-                                assert formatted_preferred_name_conf is not None
+                            if formatted_preferred_name_conf is not None:
                                 formatted_inputs[
                                     "preferred-name"
                                 ] = formatted_preferred_name_conf
-                            if "relative-dir" in inputs:
-                                assert formatted_reldir_conf is not None
+                            if formatted_reldir_conf is not None:
                                 formatted_inputs["relative-dir"] = formatted_reldir_conf
                         else:
                             formatted_inputs = inputs
@@ -2350,12 +2345,18 @@ class WF:
 
                 else:
                     # possible nested files
-                    formatted_inputs_nested = self.formatParams(
+                    (
+                        formatted_inputs_nested,
+                        child_outputs_to_inject,
+                    ) = self.formatParams(
                         cast("ParamsBlock", inputs), prefix=linearKey + "."
                     )
                     if inputs != formatted_inputs_nested:
                         some_formatted = True
                     formatted_params[key] = formatted_inputs_nested
+                    # Propagate the outputs to inject
+                    if isinstance(child_outputs_to_inject, list):
+                        outputs_to_inject.extend(child_outputs_to_inject)
             elif isinstance(raw_inputs, list):
                 if len(raw_inputs) > 0 and isinstance(raw_inputs[0], str):
                     formatted_inputs_l = []
@@ -2380,7 +2381,7 @@ class WF:
             else:
                 formatted_params[key] = raw_inputs
 
-        return formatted_params if some_formatted else params
+        return formatted_params if some_formatted else params, outputs_to_inject
 
     def _fetchContentWithURIs(
         self,
@@ -2695,12 +2696,31 @@ class WF:
                             # We have to autofill this with the outputs directory,
                             # so results are properly stored (without escaping the jail)
                             if inputs.get("autoFill", False):
-                                if inputs.get("autoPrefix", True):
+                                relative_dir = inputs.get("relative-dir")
+                                preferred_name = inputs.get("preferred-name")
+                                auto_prefix = inputs.get("autoPrefix", True)
+                                if (
+                                    relative_dir is not None
+                                    or preferred_name is not None
+                                ):
+                                    auto_prefix = True
+
+                                if auto_prefix:
+                                    if relative_dir is not None:
+                                        rel_auto_filled = relative_dir
+                                    else:
+                                        rel_auto_filled = ""
+                                    if preferred_name is not None:
+                                        the_tokens = [preferred_name]
+                                    else:
+                                        the_tokens = path_tokens
+                                    # We cannot use an absolute path because
+                                    # each run has its own output directory!!!
                                     autoFilledDir = os.path.join(
-                                        self.outputsDir, *path_tokens
+                                        rel_auto_filled, *the_tokens
                                     )
                                 else:
-                                    autoFilledDir = self.outputsDir
+                                    autoFilledDir = ""
 
                                 theInputs.append(
                                     MaterializedInput(
@@ -2715,9 +2735,22 @@ class WF:
                         elif inputClass == ContentKind.File.name and inputs.get(
                             "autoFill", False
                         ):
+                            relative_dir = inputs.get("relative-dir")
+                            preferred_name = inputs.get("preferred-name")
+                            if relative_dir is not None:
+                                rel_auto_filled = relative_dir
+                            else:
+                                rel_auto_filled = ""
+                            if preferred_name is not None:
+                                the_tokens = [preferred_name]
+                            else:
+                                the_tokens = path_tokens
+
                             # We have to autofill this with the outputs directory,
                             # so results are properly stored (without escaping the jail)
-                            autoFilledFile = os.path.join(self.outputsDir, path_tokens)
+                            autoFilledFile = os.path.join(
+                                self.outputsDir, rel_auto_filled, *the_tokens
+                            )
                             autoFilledDir = os.path.dirname(autoFilledFile)
                             # This is needed to assure the path exists
                             if autoFilledDir != self.outputsDir:
@@ -3036,9 +3069,21 @@ class WF:
     }
 
     def parseExpectedOutputs(
-        self, outputs: "Union[Sequence[Any], Mapping[str, Any]]"
+        self,
+        outputs_to_inject: "Sequence[Sch_Output]",
+        outputs: "Union[Sequence[Sch_Output], Mapping[str, Sch_Output]]",
+        default_synthetic_output: "bool",
     ) -> "Sequence[ExpectedOutput]":
         expectedOutputs = []
+        known_outputs: "Set[str]" = set()
+
+        outputs_to_process = []
+        for output_to_inject in outputs_to_inject:
+            fill_from = output_to_inject.get("fillFrom")
+            assert isinstance(fill_from, str)
+            if fill_from not in known_outputs:
+                known_outputs.add(fill_from)
+                outputs_to_process.append((fill_from, output_to_inject))
 
         # TODO: implement parsing of outputs
         outputsIter = (
@@ -3046,6 +3091,12 @@ class WF:
         )
 
         for outputKey, outputDesc in outputsIter:
+            # Skip already injected
+            if str(outputKey) not in known_outputs:
+                known_outputs.add(outputKey)
+                outputs_to_process.append((str(outputKey), outputDesc))
+
+        for output_name, outputDesc in outputs_to_process:
             # The glob pattern
             patS = outputDesc.get("glob")
             if patS is not None:
@@ -3073,7 +3124,7 @@ class WF:
                 cardinality = self.CardinalityMapping[self.DefaultCardinality]
 
             eOutput = ExpectedOutput(
-                name=outputKey,
+                name=cast("SymbolicOutputName", output_name),
                 kind=self.OutputClassMapping.get(
                     outputDesc.get("c-l-a-s-s"), ContentKind.File
                 ),
@@ -3081,6 +3132,9 @@ class WF:
                 cardinality=cardinality,
                 fillFrom=fillFrom,
                 glob=patS,
+                syntheticOutput=outputDesc.get(
+                    "syntheticOutput", default_synthetic_output
+                ),
             )
             expectedOutputs.append(eOutput)
 
@@ -3089,8 +3143,6 @@ class WF:
     def parseExportActions(
         self, raw_actions: "Sequence[ExportActionBlock]"
     ) -> "Sequence[ExportAction]":
-        assert self.outputs is not None
-
         o_raw_actions = {"exports": raw_actions}
         valErrors = config_validate(o_raw_actions, self.EXPORT_ACTIONS_SCHEMA)
         if len(valErrors) > 0:
@@ -3156,7 +3208,7 @@ class WF:
         assert self.materializedEngine is not None
         assert self.materializedParams is not None
         assert self.materializedEnvironment is not None
-        assert self.outputs is not None
+        assert self.expected_outputs is not None
 
         if self.stagedExecutions is None:
             self.stagedExecutions = []
@@ -3165,7 +3217,7 @@ class WF:
             self.materializedEngine,
             self.materializedParams,
             self.materializedEnvironment,
-            self.outputs,
+            self.expected_outputs,
         )
 
         self.stagedExecutions.append(stagedExec)
@@ -3537,8 +3589,7 @@ This is an enumeration of the types of collected contents:
         if self.placeholders is not None:
             workflow_meta["placeholders"] = self.placeholders
         if self.outputs is not None:
-            outputs = {output.name: output for output in self.outputs}
-            workflow_meta["outputs"] = outputs
+            workflow_meta["outputs"] = self.outputs
         if self.default_actions is not None:
             workflow_meta["default_actions"] = self.default_actions
 
@@ -3640,8 +3691,12 @@ This is an enumeration of the types of collected contents:
                     self.params = workflow_meta.get("params")
                     self.environment = workflow_meta.get("environment")
                     self.placeholders = workflow_meta.get("placeholders")
-                    self.formatted_params = self.formatParams(self.params)
-                    self.formatted_environment = self.formatParams(self.environment)
+                    self.outputs = workflow_meta.get("outputs")
+                    self.formatted_params, self.outputs_to_inject = self.formatParams(
+                        self.params
+                    )
+                    assert self.outputs_to_inject is not None
+                    self.formatted_environment, _ = self.formatParams(self.environment)
 
                     # The right moment to rescue this?
                     if isinstance(self.workflow_config, dict):
@@ -3649,16 +3704,6 @@ This is an enumeration of the types of collected contents:
                         if container_type_str is not None:
                             self.explicit_container_type = True
                             self.container_type_str = container_type_str
-
-                    outputsM = workflow_meta.get("outputs")
-                    if isinstance(outputsM, dict):
-                        outputs = list(outputsM.values())
-                        if len(outputs) == 0 or isinstance(outputs[0], ExpectedOutput):
-                            self.outputs = outputs
-                        else:
-                            self.outputs = self.parseExpectedOutputs(outputsM)
-                    else:
-                        self.outputs = None
 
                     defaultActionsM = workflow_meta.get("default_actions")
                     if isinstance(defaultActionsM, dict):
@@ -3904,6 +3949,24 @@ This is an enumeration of the types of collected contents:
                         self.engine = self.wfexs.instantiateEngine(
                             self.engineDesc, self.staged_setup
                         )
+
+                    # Process outputs now we have an engine
+                    if isinstance(self.outputs, dict):
+                        assert self.engine is not None
+                        assert self.outputs_to_inject is not None
+                        outputs = list(self.outputs.values())
+                        if (len(outputs) == 0 and len(self.outputs_to_inject) == 0) or (
+                            len(outputs) > 0 and isinstance(outputs[0], ExpectedOutput)
+                        ):
+                            self.expected_outputs = outputs
+                        else:
+                            self.expected_outputs = self.parseExpectedOutputs(
+                                self.outputs_to_inject,
+                                self.outputs,
+                                default_synthetic_output=not self.engine.HasExplicitOutputs(),
+                            )
+                    else:
+                        self.expected_outputs = None
             except Exception as e:
                 errmsg = "Error while unmarshalling content from stage state file {}. Reason: {}".format(
                     marshalled_stage_file, e
@@ -4574,7 +4637,7 @@ This is an enumeration of the types of collected contents:
         wrroc.addStagedWorkflowDetails(
             self.materializedParams,
             self.materializedEnvironment,
-            self.outputs,
+            self.expected_outputs,
         )
 
         # Save RO-crate as execution.crate.zip

--- a/wfexs_backend/workflow.py
+++ b/wfexs_backend/workflow.py
@@ -1421,6 +1421,7 @@ class WF:
         ) = wfexs.rocrate_toolbox.generateWorkflowMetaFromJSONLD(
             jsonld_obj, public_name
         )
+
         workflow_pid = wfexs.gen_workflow_pid(repo)
         logging.debug(
             f"Repo {repo} workflow type {workflow_type} container factory {container_type}"

--- a/wfexs_backend/workflow_engines/__init__.py
+++ b/wfexs_backend/workflow_engines/__init__.py
@@ -1147,6 +1147,10 @@ class WorkflowEngine(AbstractWorkflowEngineType):
                 expectedCardinality=expectedOutput.cardinality,
                 values=expMatContents if len(expMatContents) > 0 else expMatValues,
                 syntheticOutput=expectedOutput.syntheticOutput,
+                filledFrom=expectedOutput.fillFrom
+                if expectedOutput.syntheticOutput
+                else None,
+                glob=expectedOutput.glob if expectedOutput.syntheticOutput else None,
             )
 
             matOutputs.append(matOutput)

--- a/wfexs_backend/workflow_engines/__init__.py
+++ b/wfexs_backend/workflow_engines/__init__.py
@@ -173,6 +173,10 @@ class WorkflowType(NamedTuple):
     def _value_fixes(cls) -> "Mapping[str, Optional[str]]":
         return {"shortname": "trs_descriptor"}
 
+    @property
+    def has_explicit_outputs(self) -> "bool":
+        return self.clazz.HasExplicitOutputs()
+
 
 class MaterializedWorkflowEngine(NamedTuple):
     """
@@ -201,6 +205,11 @@ class AbstractWorkflowEngineType(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def MyWorkflowType(cls) -> "WorkflowType":
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def HasExplicitOutputs(cls) -> "bool":
         pass
 
     @property
@@ -788,8 +797,12 @@ class WorkflowEngine(AbstractWorkflowEngineType):
     def staged_containers_dir(self) -> "AnyPath":
         return self.stagedContainersDir
 
-    def create_job_directories(self) -> "Tuple[str, AbsPath, AbsPath]":
+    def create_job_directories(self) -> "Tuple[str, AbsPath, AbsPath, AbsPath]":
         outputDirPostfix = "_" + str(int(time.time())) + "_" + str(os.getpid())
+        intermediateDir = cast(
+            "AbsPath", os.path.join(self.intermediateDir, outputDirPostfix)
+        )
+        os.makedirs(intermediateDir, exist_ok=True)
         outputsDir = cast("AbsPath", os.path.join(self.outputsDir, outputDirPostfix))
         os.makedirs(outputsDir, exist_ok=True)
         outputMetaDir = cast(
@@ -797,7 +810,7 @@ class WorkflowEngine(AbstractWorkflowEngineType):
         )
         os.makedirs(outputMetaDir, exist_ok=True)
 
-        return outputDirPostfix, outputsDir, outputMetaDir
+        return outputDirPostfix, intermediateDir, outputsDir, outputMetaDir
 
     @abc.abstractmethod
     def launchWorkflow(
@@ -956,6 +969,7 @@ class WorkflowEngine(AbstractWorkflowEngineType):
                             kind=guessedOutputKindDef,
                             expectedCardinality=self.GuessedCardinalityMapping[False],
                             values=matValuesDef,
+                            syntheticOutput=True,
                         )
 
                         matOutputs.append(matOutput)
@@ -983,6 +997,7 @@ class WorkflowEngine(AbstractWorkflowEngineType):
                                 len(matValues) > 1
                             ],
                             values=matValues,
+                            syntheticOutput=False,
                         )
 
                         matOutputs.append(matOutput)
@@ -998,11 +1013,15 @@ class WorkflowEngine(AbstractWorkflowEngineType):
                     for matchedPath in matInputValues:
                         # FIXME: Are these elements always paths??????
                         if isinstance(matchedPath, str):
+                            if os.path.isabs(matchedPath):
+                                abs_matched_path = matchedPath
+                            else:
+                                abs_matched_path = os.path.join(outputsDir, matchedPath)
                             try:
                                 theContent: "AbstractGeneratedContent"
                                 if expectedOutput.kind == ContentKind.Directory:
                                     theContent = GetGeneratedDirectoryContent(
-                                        thePath=cast("AbsPath", matchedPath),
+                                        thePath=cast("AbsPath", abs_matched_path),
                                         uri=None,  # TODO: generate URIs when it is advised
                                         preferredFilename=expectedOutput.preferredFilename,
                                         signatureMethod=nihDigester,
@@ -1010,12 +1029,12 @@ class WorkflowEngine(AbstractWorkflowEngineType):
                                     expMatContents.append(theContent)
                                 elif expectedOutput.kind == ContentKind.File:
                                     theContent = GeneratedContent(
-                                        local=cast("AbsPath", matchedPath),
+                                        local=cast("AbsPath", abs_matched_path),
                                         uri=None,  # TODO: generate URIs when it is advised
                                         signature=cast(
                                             "Fingerprint",
                                             ComputeDigestFromFile(
-                                                matchedPath, repMethod=nihDigester
+                                                abs_matched_path, repMethod=nihDigester
                                             ),
                                         ),
                                         preferredFilename=expectedOutput.preferredFilename,
@@ -1034,15 +1053,19 @@ class WorkflowEngine(AbstractWorkflowEngineType):
                                     ) as mP:
                                         theValue = mP.read()
                                         expMatValues.append(theValue)
-                            except:
-                                self.logger.error(
-                                    f"Unable to read path {matchedPath} from filled input {expectedOutput.fillFrom}"
+                            except Exception as e:
+                                self.logger.exception(
+                                    f"Unable to read path {abs_matched_path} ({matchedPath}) from filled input {expectedOutput.fillFrom}"
                                 )
                         else:
                             self.logger.exception("FIXME!!!!!!!!!!!!")
                             raise WorkflowEngineException("FIXME!!!!!!!!!!!!")
 
-                if len(expMatValues) == 0 and cannotBeEmpty:
+                if (
+                    len(expMatValues) == 0
+                    and len(expMatContents) == 0
+                    and cannotBeEmpty
+                ):
                     self.logger.warning(
                         f"Output {expectedOutput.name} got no path from filled input {expectedOutput.fillFrom}"
                     )
@@ -1123,6 +1146,7 @@ class WorkflowEngine(AbstractWorkflowEngineType):
                 kind=expectedOutput.kind,
                 expectedCardinality=expectedOutput.cardinality,
                 values=expMatContents if len(expMatContents) > 0 else expMatValues,
+                syntheticOutput=expectedOutput.syntheticOutput,
             )
 
             matOutputs.append(matOutput)

--- a/wfexs_backend/workflow_engines/__init__.py
+++ b/wfexs_backend/workflow_engines/__init__.py
@@ -1122,6 +1122,9 @@ class WorkflowEngine(AbstractWorkflowEngineType):
                             matchedValue = mP.read()
                             expMatValues.append(matchedValue)
             else:
+                assert (
+                    self.HasExplicitOutputs()
+                ), f"Workflow engine {self.MyWorkflowType().engineName} does not support explicit outputs, but received {expectedOutput}"
                 outputVal = outputsMapping.get(expectedOutput.name)
 
                 if (outputVal is None) and cannotBeEmpty:
@@ -1147,9 +1150,7 @@ class WorkflowEngine(AbstractWorkflowEngineType):
                 expectedCardinality=expectedOutput.cardinality,
                 values=expMatContents if len(expMatContents) > 0 else expMatValues,
                 syntheticOutput=expectedOutput.syntheticOutput,
-                filledFrom=expectedOutput.fillFrom
-                if expectedOutput.syntheticOutput
-                else None,
+                filledFrom=expectedOutput.fillFrom,
                 glob=expectedOutput.glob if expectedOutput.syntheticOutput else None,
             )
 

--- a/wfexs_backend/workflow_engines/cwl_engine.py
+++ b/wfexs_backend/workflow_engines/cwl_engine.py
@@ -302,6 +302,11 @@ class CWLWorkflowEngine(WorkflowEngine):
         )
 
     @classmethod
+    def HasExplicitOutputs(cls) -> "bool":
+        # CWL has a clear separation between inputs and outputs
+        return True
+
+    @classmethod
     def SupportedContainerTypes(cls) -> "Set[ContainerType]":
         return cls.SUPPORTED_CONTAINER_TYPES
 
@@ -934,7 +939,12 @@ STDERR
             )
         engineVersion = matWfEng.version
 
-        outputDirPostfix, outputsDir, outputMetaDir = self.create_job_directories()
+        (
+            outputDirPostfix,
+            intermediateDir,
+            outputsDir,
+            outputMetaDir,
+        ) = self.create_job_directories()
         outputStatsDir = os.path.join(outputMetaDir, WORKDIR_STATS_RELDIR)
         os.makedirs(outputStatsDir, exist_ok=True)
 
@@ -1031,7 +1041,7 @@ STDERR
                     # the workflow
                     with open(stdoutFilename, mode="wb+") as cwl_yaml_stdout:
                         with open(stderrFilename, mode="ab+") as cwl_yaml_stderr:
-                            intermediateDir = self.intermediateDir + "/"
+                            jobIntermediateDir = intermediateDir + "/"
                             outputDir = outputsDir + "/"
 
                             # This is needed to isolate execution environment
@@ -1066,8 +1076,8 @@ STDERR
                                 f"{cwltool_install_dir}/bin/cwltool",
                                 *debugFlags,
                                 "--outdir=" + outputDir,
-                                "--tmp-outdir-prefix=" + intermediateDir,
-                                "--tmpdir-prefix=" + intermediateDir,
+                                "--tmp-outdir-prefix=" + jobIntermediateDir,
+                                "--tmpdir-prefix=" + jobIntermediateDir,
                                 "--strict",
                                 "--no-doc-cache",
                             ]


### PR DESCRIPTION
This merge includes many fixes around RO-Crate generation and consumption, as well as processing hints.

* Generated RO-Crates with detached inputs were not properly including either `contentUrl` or `identifier` properties.
* SPARQL queries were not capturing the optional nature of input and output `contentUrl` , and added querying about `identifier` as an alternate for `contentUrl`.
* Code now considers `identifier` as an alternate provider of file or dataset input PIDs.
* The concept of synthetic output has been added, in order to distinguish output parameters from synthetic ones added to ease the selection of results from an output directory.
* Hints about output path linking to parameters (needed for Nextflow and future Snakemake support)  have been added.
* Hints about glob patterns for synthetic outputs have also been added.