### PR TITLE
Partial fix for issue #128

### DIFF
--- a/wfexs_backend/utils/rocrate.py
+++ b/wfexs_backend/utils/rocrate.py
@@ -2491,6 +2491,24 @@ WHERE   {
         if langrow.workflow_alternate_name is not None:
             repo_relpath = str(langrow.workflow_alternate_name)
 
+        # A fallback
+        if repo_relpath is None:
+            self.logger.warning(
+                f"Deriving relative path of workflow entry point from entry point location in RO-Crate metadata"
+            )
+            main_entity_uri = str(main_entity)
+            main_entity_parsed_uri = urllib.parse.urlparse(main_entity_uri)
+            use_main_entity = (
+                main_entity_parsed_uri.scheme == self.RELATIVE_ROCRATE_SCHEME
+            )
+
+            if use_main_entity:
+                entity_path = urllib.parse.unquote(main_entity_parsed_uri.path)
+                if entity_path.startswith("/"):
+                    entity_path = entity_path[1:]
+
+                repo_relpath = entity_path
+
         repo_web_url: "Optional[str]" = None
         if langrow.workflow_url is not None:
             repo_web_url = str(langrow.workflow_url)

--- a/wfexs_backend/workflow.py
+++ b/wfexs_backend/workflow.py
@@ -2016,6 +2016,7 @@ class WF:
                     offline=offline,
                     meta_dir=self.metaDir,
                 )
+                self.logger.error(repo)
 
             self.remote_repo = repo
             # These are kept for compatibility
@@ -2078,15 +2079,15 @@ class WF:
         )
         self.logger.info(
             "materialized workflow repository (checkout {}): {}".format(
-                self.repoEffectiveCheckout, self.workflowDir
+                self.repoEffectiveCheckout, localWorkflow.dir
             )
         )
 
-        if self.repoRelPath is not None:
-            if not (self.workflowDir / self.repoRelPath).exists():
+        if localWorkflow.relPath is not None:
+            if not (localWorkflow.dir / localWorkflow.relPath).exists():
                 raise WFException(
                     "Relative path {} cannot be found in materialized workflow repository {}".format(
-                        self.repoRelPath, self.workflowDir
+                        localWorkflow.relPath, localWorkflow.dir
                     )
                 )
         # A valid engine must be identified from the fetched content
@@ -2126,6 +2127,7 @@ class WF:
             self.logger.debug("Fixed engine " + self.engineDesc.trs_descriptor)
             engine = self.wfexs.instantiateEngine(self.engineDesc, self.staged_setup)
             engineVer, candidateLocalWorkflow = engine.identifyWorkflow(localWorkflow)
+            self.logger.error(localWorkflow)
             if engineVer is None:
                 raise WFException(
                     "Engine {} did not recognize a workflow at {}".format(

--- a/wfexs_backend/workflow.py
+++ b/wfexs_backend/workflow.py
@@ -2016,7 +2016,6 @@ class WF:
                     offline=offline,
                     meta_dir=self.metaDir,
                 )
-                self.logger.error(repo)
 
             self.remote_repo = repo
             # These are kept for compatibility
@@ -2127,7 +2126,6 @@ class WF:
             self.logger.debug("Fixed engine " + self.engineDesc.trs_descriptor)
             engine = self.wfexs.instantiateEngine(self.engineDesc, self.staged_setup)
             engineVer, candidateLocalWorkflow = engine.identifyWorkflow(localWorkflow)
-            self.logger.error(localWorkflow)
             if engineVer is None:
                 raise WFException(
                     "Engine {} did not recognize a workflow at {}".format(

--- a/wfexs_backend/workflow.py
+++ b/wfexs_backend/workflow.py
@@ -1330,6 +1330,32 @@ class WF:
         )
 
     @classmethod
+    def TryWorkflowURI(
+        cls,
+        wfexs: "WfExSBackend",
+        workflow_uri: "str",
+        securityContextsConfigFilename: "Optional[pathlib.Path]" = None,
+        nickname_prefix: "Optional[str]" = None,
+    ) -> "WF":
+        """
+        This class method creates a new staged working directory
+        """
+
+        workflow_meta = {
+            "workflow_id": workflow_uri,
+            "workflow_config": {"secure": False},
+            "params": {},
+        }
+
+        return cls.FromStagedRecipe(
+            wfexs,
+            workflow_meta,
+            securityContextsConfigFilename=securityContextsConfigFilename,
+            nickname_prefix=nickname_prefix,
+            reproducibility_level=ReproducibilityLevel.Minimal,
+        )
+
+    @classmethod
     def FromFiles(
         cls,
         wfexs: "WfExSBackend",
@@ -3573,6 +3599,33 @@ class WF:
                 )
 
         return theInputs, lastInput, the_failed_uris
+
+    def tryStageWorkflow(
+        self, offline: "bool" = False, ignoreCache: "bool" = False
+    ) -> "StagedSetup":
+        """
+        This method is here to try materializing and identifying a workflow
+        """
+
+        # Inputs should be materialized before materializing the workflow itself
+        # because some workflow systems could need them in order to describe
+        # some its internal details.
+        #
+        # But as we are trying to materialize a bare workflow, no input
+        # is going to be provided
+
+        # This method is called from within setupEngine
+        # self.fetchWorkflow(self.id, self.version_id, self.trs_endpoint, self.descriptor_type)
+        # This method is called from within materializeWorkflowAndContainers
+        # self.setupEngine(offline=offline)
+        self.materializeWorkflowAndContainers(
+            offline=offline,
+            ignoreCache=ignoreCache,
+        )
+
+        self.marshallStage()
+
+        return self.getStagedSetup()
 
     def stageWorkDir(
         self, offline: "bool" = False, ignoreCache: "bool" = False


### PR DESCRIPTION
Issue #128 was about code was not including a reasonable default for the entrypoint when the details are rescued from an incomplete RO-Crate obtained as workflow source.

These commits rescue the relative path of the workflow entry point from the main entity, which could not be true within the original repository.