### PR TITLE
131 errors in downloading from skullsecurityorg during installation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,5 +28,5 @@ repository-code: "https://github.com/inab/WfExS-backend"
 repository-artifact: "https://github.com/inab/WfExS-backend/pkgs/container/wfexs-backend"
 type: software
 title: "WfExS-backend"
-version: 1.0.0rc1
-date-released: "2024-10-16"
+version: 1.0.0rc2
+date-released: "2024-12-03"

--- a/WfExS-config-replicator.py
+++ b/WfExS-config-replicator.py
@@ -110,13 +110,13 @@ def loadXLSXParams(paramsFilename: "str") -> "Sequence[Mapping[str, Any]]":
         # by latest openpyxl annotations
         sheet = cast("Worksheet", sheet_raw)  # type: ignore[redundant-cast]
         gotHeader = False
-        headerMap: "MutableMapping[int,str]" = {}
+        headerMap: "MutableMapping[Optional[int],str]" = {}
         for cells_in_row in sheet.iter_rows():
             # Either get the header or the data
             if gotHeader:
                 params: "MutableMapping[str, MutableSequence[Any]]" = dict()
                 for cell in cells_in_row:
-                    headerName = headerMap.get(cell.col_idx)
+                    headerName = headerMap.get(cell.column)
                     if headerName is not None:
                         theVal = cell.value
                         params.setdefault(headerName, []).append(theVal)
@@ -129,7 +129,7 @@ def loadXLSXParams(paramsFilename: "str") -> "Sequence[Mapping[str, Any]]":
                         if len(headerName) > 0:
                             gotHeader = True
                             # The column index is 1-based
-                            headerMap[cell.col_idx] = headerName
+                            headerMap[cell.column] = headerName
 
     return paramsArray
 

--- a/wfexs_backend/__init__.py
+++ b/wfexs_backend/__init__.py
@@ -21,7 +21,7 @@ __copyright__ = "© 2020-2024 Barcelona Supercomputing Center (BSC), ES"
 __license__ = "Apache 2.0"
 
 # https://www.python.org/dev/peps/pep-0396/
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0rc2"
 __url__ = "https://github.com/inab/WfExS-backend"
 __official_name__ = "WfExS-backend"
 

--- a/wfexs_backend/utils/passphrase_wrapper.py
+++ b/wfexs_backend/utils/passphrase_wrapper.py
@@ -77,9 +77,11 @@ class WfExSPassphraseGenerator:
             )
         ],
         "cain": [
+            # Originally
             # https://wiki.skullsecurity.org/index.php/Passwords
+            # and http://downloads.skullsecurity.org/passwords/cain.txt.bz2
             RemoteWordlistResource(
-                "http://downloads.skullsecurity.org/passwords/cain.txt.bz2"
+                "https://github.com/duyet/bruteforce-database/raw/233b5e59a87b96ec696ddcb33b8a37709ca6aa8a/cain.txt"
             ),
         ],
         "adjectives": [


### PR DESCRIPTION
Just these past days the SSL certificate supporting https://downloads.skullsecurity.org/passwords/cain.txt.bz2 (which is reached after being redirected from http://downloads.skullsecurity.org/passwords/cain.txt.bz2) was expired, so populate-side-caches command fails on wordlist materialisation.

This pull request replaces it with a longer term source (i.e. an specific commit from a repository holding the very same file, but uncompressed), as well as it adds the machinery to avoid failing during the side cache initialization process.