### PR TITLE
(Take 2) Fixed issue with image building CI workflow

### DIFF
--- a/.github/workflows/image-publishing.yml
+++ b/.github/workflows/image-publishing.yml
@@ -50,8 +50,8 @@ jobs:
         uses: docker/build-push-action@v6.10.0
         with:
           context: container_recipes
-          build-args:
-            - wfexs_checkout=${{ github.sha }}
+          build-args: |
+            wfexs_checkout=${{ github.sha }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,4 +29,4 @@ repository-artifact: "https://github.com/inab/WfExS-backend/pkgs/container/wfexs
 type: software
 title: "WfExS-backend"
 version: 1.0.0rc2
-date-released: "2024-12-03"
+date-released: "2024-12-05"


### PR DESCRIPTION
It arose while publishing fix for issue #131. The CI workflow misspelled the `build-args` parameter for the [docker/build-push-action](https://github.com/docker/build-push-action).