### PR TITLE
140 apptainer installer scripts do not work any more

### DIFF
--- a/container_recipes/Dockerfile
+++ b/container_recipes/Dockerfile
@@ -11,14 +11,14 @@ RUN	git clone --filter=blob:none --no-checkout https://github.com/jmfernandez/su
 FROM	python:3.12 AS podman_build
 # These arguments help customizing what it is included in the generated image
 ARG	wfexs_checkout=0910fe6eec015c7a112f129f0adb4a998ef27a8c
-ARG	apptainer_version=1.3.3
+ARG	apptainer_version=1.3.6
 # JDK version parameters
 ARG	JDK_MAJOR_VER=11
 ARG	JDK_VER=${JDK_MAJOR_VER}.0.11
 ARG	JDK_REV=9
 ARG	OPENJ9_VER=0.26.0
 # Go version to compile
-ARG	GO_VER=1.17.13
+ARG	GO_VER=1.20.14
 # gocryptfs version
 ARG	GOCRYPTFS_VER=v2.4.0
 # static bash version

--- a/container_recipes/Singularity.def
+++ b/container_recipes/Singularity.def
@@ -6,7 +6,7 @@ Stage: spython-base
 # The default images of python are based on debian
 # These arguments help customizing what it is included in the generated image
 wfexs_checkout=574fe343c0b59eecd95afbc67894456359ebe649
-apptainer_version=1.3.3
+apptainer_version=1.3.6
 # JDK version parameters
 JDK_MAJOR_VER=11
 # Nested arguments are not allowed
@@ -14,7 +14,7 @@ JDK_VER=11.0.11
 JDK_REV=9
 OPENJ9_VER=0.26.0
 # Go version to compile
-GO_VER=1.17.13
+GO_VER=1.20.14
 # gocryptfs version
 GOCRYPTFS_VER=v2.4.0
 # static bash version

--- a/container_recipes/apptainer12-local-installer.bash
+++ b/container_recipes/apptainer12-local-installer.bash
@@ -17,12 +17,12 @@
 
 # These are the software versions being installed
 # in the virtual environment
-APPTAINER_VER=1.2.2
-GO_VER=1.20.7
+: ${APPTAINER_VER:=1.2.5}
+: ${GO_VER:=1.20.14}
 
 # These are placeholders
-GO_OS=linux
-GO_ARCH=amd64
+: ${GO_OS:=linux}
+: ${GO_ARCH:=amd64}
 
 # Getting the installation directory
 wfexsDir="$(dirname "$0")"
@@ -48,9 +48,15 @@ cleanup() {
 	rm -rf "${downloadDir}"
 }
 
-trap cleanup EXIT ERR
+cleanuperr() {
+	cleanup
+	exit 1
+}
 
-set -e
+trap cleanup EXIT
+trap cleanuperr ERR
+
+set -eu
 
 doForce=
 if [ $# -gt 0 ]; then
@@ -79,17 +85,21 @@ if [ $# -gt 0 ]; then
 fi
 # Second, let's load the environment in order to install
 # apptainer in the python profile
+trap - ERR
 source "$wfexsDir"/basic-installer.bash
 
 failed=
 for cmd in mksquashfs squashfuse fuse2fs ; do
+	set +e
 	type -a "$cmd" 2> /dev/null
 	retval=$?
+	set -e
 	if [ "$retval" -ne 0 ] ; then
 		failed=1
 		echo "ERROR: Command $cmd not found in PATH and needed for the installation"
 	fi
 done
+trap cleanuperr ERR
 
 if [ -n "$failed" ] ; then
 	exit 1

--- a/container_recipes/apptainer13-local-installer.bash
+++ b/container_recipes/apptainer13-local-installer.bash
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020-2024 Barcelona Supercomputing Center (BSC), Spain
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These are the software versions being installed
+# in the virtual environment
+: ${APPTAINER_VER:=1.3.6}
+: ${GO_VER:=1.23.4}
+
+# These are placeholders
+: ${GO_OS:=linux}
+: ${GO_ARCH:=amd64}
+
+# Getting the installation directory
+wfexsDir="$(dirname "$0")"
+case "${wfexsDir}" in
+	/*)
+		# Path is absolute
+		true
+	;;
+	*)
+		# Path is relative
+		wfexsDir="$(readlink -f "${wfexsDir}")"
+	;;
+esac
+
+downloadDir="$(mktemp -d --tmpdir wfexs_apptainer_installer.XXXXXXXXXXX)"
+echo "$0: ${downloadDir} will be used to download third party dependencies, and later removed"
+
+cleanup() {
+	set +e
+	# This is needed in order to avoid
+	# lots of "permission denied" messages
+	chmod -R u+w "${downloadDir}"
+	rm -rf "${downloadDir}"
+}
+
+cleanuperr() {
+	cleanup
+	exit 1
+}
+
+trap cleanup EXIT
+trap cleanuperr ERR
+
+set -eu
+
+doForce=
+if [ $# -gt 0 ]; then
+	if [ "$1" == "force" ] ; then
+		doForce=1
+		if [ $# -gt 1 ] ; then
+			APPTAINER_VER="$2"
+			if [ $# -gt 2 ] ; then
+				GO_VER="$3"
+			fi
+		fi
+	fi
+fi
+
+# Before installing, check whether apptainer is already available
+if [ -z "$doForce" ] ; then
+	if type -a apptainer >& /dev/null ; then
+		echo "Apptainer $(apptainer version) is already available in the system. Skipping install"
+		exit 0
+	fi
+fi
+
+# First, be sure the environment is ready to be used
+if [ $# -gt 0 ]; then
+	shift $#
+fi
+# Second, let's load the environment in order to install
+# apptainer in the python profile
+trap - ERR
+source "$wfexsDir"/basic-installer.bash
+
+failed=
+for cmd in mksquashfs squashfuse fuse2fs ; do
+	set +e
+	type -a "$cmd" 2> /dev/null
+	retval=$?
+	set -e
+	if [ "$retval" -ne 0 ] ; then
+		failed=1
+		echo "ERROR: Command $cmd not found in PATH and needed for the installation"
+	fi
+done
+trap cleanuperr ERR
+
+if [ -n "$failed" ] ; then
+	exit 1
+fi
+
+
+# Now, it is time to check apptainer binaries availability
+if [ -z "$doForce" ] ; then
+	if [ -x "${envDir}/bin/apptainer" ] ; then
+		echo "Apptainer $(apptainer version) is already available in the environment. Skipping install"
+		exit 0
+	fi
+fi
+
+# Compilation artifacts should go to the temporary download directory
+checkInstallGO "${GO_VER}" "${platformOS}" "${platformArchGO}" "${downloadDir}"
+
+# Fetch and compile apptainer
+apptainerBundlePrefix=apptainer-"${APPTAINER_VER}"
+apptainerBundle="${apptainerBundlePrefix}".tar.gz
+
+( cd "${downloadDir}" && curl -L -O https://github.com/apptainer/apptainer/releases/download/v"${APPTAINER_VER}"/"${apptainerBundle}" )
+tar -x -z -C "${downloadDir}" -f "${downloadDir}/${apptainerBundle}"
+# Removing apptainer bundle
+rm "${downloadDir}/${apptainerBundle}"
+cd "${downloadDir}"/"${apptainerBundlePrefix}"
+
+# Now, the right moment to compile and install rootless apptainer
+./mconfig -b ./builddir --without-suid --prefix="${envDir}"
+make -C ./builddir
+make -C ./builddir install
+
+# Last, in order to keep compatibility, there should be a symlink called
+# singularity pointing to apptainer
+ln -sf apptainer "${envDir}"/bin/singularity

--- a/container_recipes/basic-installer.bash
+++ b/container_recipes/basic-installer.bash
@@ -155,8 +155,6 @@ except:
 
 sys.exit(0)
 EOF
-	python3 -P -c "$CHECKWFEXS"
-	retval=$?
 else
 	python_p_flag=""
 	read -r -d "" CHECKWFEXS <<EOF
@@ -183,11 +181,16 @@ except:
 sys.exit(0)
 EOF
 fi
-python3 $python_p_flag -c "$CHECKWFEXS"
+if [ -d "${scriptDir}"/../wfexs_backend ] ; then
+	pythonpath_env="${scriptDir}/..:$PYTHONPATH"
+else
+	pythonpath_env="$PYTHONPATH"
+fi
+PYTHONPATH="$pythonpath_env" python3 $python_p_flag -c "$CHECKWFEXS"
 retval=$?
 set -eu
 if [ "$retval" -eq 0 ] ; then
-	envDir="$(python3 -c 'import sys; print(sys.prefix)')"
+	envDir="$(PYTHONPATH="$pythonpath_env" python3 -c 'import sys; print(sys.prefix)')"
 else
 	envDir=""
 fi
@@ -199,7 +202,7 @@ if [ -z "$envDir" ]; then
 	requirementsFile="$(readlink -f "${scriptDir}"/../requirements.txt)"
 	wfexsDir="$(dirname "${requirementsFile}")"
 
-	envDir="$(python3 -c 'import sys; print(""  if sys.prefix==sys.base_prefix  else  sys.prefix)')"
+	envDir="$(PYTHONPATH="$pythonpath_env" python3 -c 'import sys; print(""  if sys.prefix==sys.base_prefix  else  sys.prefix)')"
 	if [ -n "${envDir}" ] ; then
 		echo "Using currently active environment ${envDir} to install the dependencies"
 	elif [ ! -f "${requirementsFile}" ] ; then


### PR DESCRIPTION
Fixed issue with scripts which allow to install apptainer in the python environment, which are needed for native installs in restricted environments like HPC ones.