### PR TITLE
Implemented proof of concept which detects parameters with default va…

### DIFF
--- a/wfexs_backend/workflow.py
+++ b/wfexs_backend/workflow.py
@@ -2378,6 +2378,7 @@ class WF:
                 profiles=self.enabled_profiles,
                 context_inputs=context_inputs,
                 context_environment=context_environment,
+                remote_repo=self.remote_repo,
             )
 
     def materializeInputs(

--- a/wfexs_backend/workflow_engines/__init__.py
+++ b/wfexs_backend/workflow_engines/__init__.py
@@ -106,6 +106,10 @@ if TYPE_CHECKING:
         ProcessorArchitecture,
     )
 
+    from ..fetchers import (
+        RemoteRepo,
+    )
+
     EngineLocalConfig: TypeAlias = Mapping[str, Any]
 
     # This is also an absolute path
@@ -368,6 +372,7 @@ class AbstractWorkflowEngineType(abc.ABC):
         profiles: "Optional[Sequence[str]]" = None,
         context_inputs: "Sequence[MaterializedInput]" = [],
         context_environment: "Sequence[MaterializedInput]" = [],
+        remote_repo: "Optional[RemoteRepo]" = None,
     ) -> "Tuple[MaterializedWorkflowEngine, Sequence[ContainerTaggedName]]":
         """
         Method to ensure the workflow has been materialized. It returns a
@@ -847,6 +852,7 @@ class WorkflowEngine(AbstractWorkflowEngineType):
         profiles: "Optional[Sequence[str]]" = None,
         context_inputs: "Sequence[MaterializedInput]" = [],
         context_environment: "Sequence[MaterializedInput]" = [],
+        remote_repo: "Optional[RemoteRepo]" = None,
     ) -> "Tuple[MaterializedWorkflowEngine, Sequence[ContainerTaggedName]]":
         """
         Method to ensure the workflow has been materialized. It returns the
@@ -982,6 +988,7 @@ class WorkflowEngine(AbstractWorkflowEngineType):
         profiles: "Optional[Sequence[str]]" = None,
         context_inputs: "Sequence[MaterializedInput]" = [],
         context_environment: "Sequence[MaterializedInput]" = [],
+        remote_repo: "Optional[RemoteRepo]" = None,
     ) -> "Tuple[MaterializedWorkflowEngine, ContainerEngineVersionStr, ContainerOperatingSystem, ProcessorArchitecture]":
         matWfEngV2, listOfContainerTags = matWfEng.instance.materializeWorkflow(
             matWfEng,
@@ -990,6 +997,7 @@ class WorkflowEngine(AbstractWorkflowEngineType):
             profiles=profiles,
             context_inputs=context_inputs,
             context_environment=context_environment,
+            remote_repo=remote_repo,
         )
 
         (

--- a/wfexs_backend/workflow_engines/cwl_engine.py
+++ b/wfexs_backend/workflow_engines/cwl_engine.py
@@ -86,6 +86,10 @@ if TYPE_CHECKING:
         ContainerFactory,
     )
 
+    from ..fetchers import (
+        RemoteRepo,
+    )
+
     ExecInputVal: TypeAlias = Union[
         bool,
         int,
@@ -868,6 +872,7 @@ STDERR
         profiles: "Optional[Sequence[str]]" = None,
         context_inputs: "Sequence[MaterializedInput]" = [],
         context_environment: "Sequence[MaterializedInput]" = [],
+        remote_repo: "Optional[RemoteRepo]" = None,
     ) -> "Tuple[MaterializedWorkflowEngine, Sequence[ContainerTaggedName]]":
         """
         Method to ensure the workflow has been materialized. In the case


### PR DESCRIPTION
…lues which are paths within the repo.

This is the seed of smarter, future implementations, where either the detected parameters are not included in the RO-Crate, or they are properly added, referring the right location within the repository.